### PR TITLE
docs: storyboard, ui spec, parity checklist

### DIFF
--- a/docs/parity_checklist.md
+++ b/docs/parity_checklist.md
@@ -1,0 +1,12 @@
+# Parity Checklist
+
+The reference video `Enregistrement 2025-08-11 200846 (1).mp4` is not available, preventing parity verification.
+
+- [ ] Video accessible
+- [ ] Storyboard extracted
+- [ ] OCR performed
+- [ ] UI wording confirmed
+
+Current parity: 0%
+
+Ambiguities are noted until the video is provided.

--- a/docs/storyboard/README.md
+++ b/docs/storyboard/README.md
@@ -1,0 +1,1 @@
+No storyboard frames generated. Source video "Enregistrement 2025-08-11 200846 (1).mp4" not found in repository.

--- a/docs/ui_spec.md
+++ b/docs/ui_spec.md
@@ -1,0 +1,10 @@
+# UI Specification
+
+Source video `Enregistrement 2025-08-11 200846 (1).mp4` is missing from the repository. Without the video, exact screens, wording, and interactions cannot be documented.
+
+## Known requirements
+- Follow instructions described in project brief.
+- Document will be updated once video becomes available.
+
+## Ambiguities
+- All UI labels, placeholders, and interactions remain unspecified pending video access.


### PR DESCRIPTION
## Summary
- add placeholder storyboard directory and note missing reference video
- document UI specification ambiguities pending video access
- record parity checklist at 0% until video is supplied

## Testing
- `ls "Enregistrement 2025-08-11 200846 (1).mp4"` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689caee436d88332aa2a99c44be32619